### PR TITLE
Initialize monorepo structure with backend and frontend workspaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Python
+__pycache__/
+*.py[cod]
+*.db
+
+# Environments
+.env
+venv/
+
+# Node
+node_modules/
+dist/
+build/
+
+# Misc
+*.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# Interview-scheduling-agent-system
+# Interview Scheduling Agent System
 
-a agentic ai based agent system using python, fast api, lang chain, lang graph, azure open ai models.
-react + next js, tailwind css, shadcn components
+Monorepo containing services and infrastructure for an agentic interview scheduling system.
+
+## Workspaces
+- **backend/** – Python LangGraph service that orchestrates interview scheduling.
+- **frontend/** – Admin-only React single page application for configuration and monitoring.
+- **ops/** – Container, compose, and deployment assets.
+
+## Quickstart
+1. Navigate to a workspace directory and follow its README to install dependencies and run locally.
+2. Use `.editorconfig` and repository lint rules to keep code style consistent.
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,14 @@
+# Backend
+
+Python service built with FastAPI and LangGraph.
+
+## Running Locally
+1. Create and activate a virtual environment.
+2. Install dependencies: `pip install -r requirements.txt` (requirements file to be defined).
+3. Set required environment variables:
+   - `OPENAI_API_KEY` – API key for model access.
+4. Start the API server: `uvicorn app:app --reload`.
+
+## Development
+- Lint with `flake8`.
+- Run tests with `pytest`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,11 @@
+# Frontend
+
+Admin-only React single page application.
+
+## Running Locally
+1. Install dependencies: `npm install`.
+2. Start dev server: `npm start`.
+
+## Development
+- Lint with `eslint` and `prettier`.
+- Run tests with `npm test`.

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,7 @@
+# Ops
+
+Operations, containers, and deployment configuration.
+
+- Dockerfiles and images live here.
+- `docker-compose.yml` for local orchestration.
+- Deployment manifests and scripts for cloud environments.


### PR DESCRIPTION
## Summary
- Scaffold backend, frontend, and ops workspaces for interview scheduling system
- Add project and workspace README guides
- Configure shared editor settings and basic gitignore

## Testing
- `python -m compileall -q .`
- `flake8 .`
- `python -m unittest`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_68af65e548d88325bc399f901f3c1d72