### PR TITLE
chore: add developer tooling scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing Guidelines
+
+## Branch Naming
+Use descriptive branches such as `feature/short-description` or `bugfix/issue-id`.
+
+## Commit Messages
+Write concise, imperative commit messages. Prefix with a verb and keep the first line under 50 characters.
+
+## Pull Request Checks
+Before opening a PR, run:
+- `npm test`
+- `npm run lint`
+- `npm run dev` for a quick smoke test
+Ensure all checks pass and provide context in the PR description.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.RECIPEPREFIX := >
+.PHONY: dev test lint seed build
+
+dev:
+> npm run dev
+
+test:
+> npm test
+
+lint:
+> npm run lint
+
+seed:
+> npm run seed
+
+build:
+> npm run build

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "interview-scheduling-agent-system",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "echo 'Starting dev server (placeholder)'",
+    "test": "echo 'Running tests (placeholder)'",
+    "lint": "echo 'Linting (placeholder)'",
+    "seed": "echo 'Seeding data (placeholder)'",
+    "build": "echo 'Building project (placeholder)'"
+  }
+}


### PR DESCRIPTION
## Summary
- add placeholder npm scripts for dev, test, lint, seed, build
- wire Makefile targets to npm scripts
- document branch naming, commit message style and PR checks

## Testing
- `npm test`
- `npm run lint`
- `npm run dev`
- `npm run seed`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af66c2d1188325ac882f77822f3fef