### PR TITLE
fix: declare email validator dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi",
     "uvicorn",
+    "email-validator",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- add `email-validator` to backend dependencies so Pydantic `EmailStr` works

## Testing
- `flake8 app/domain/models.py app/domain/schemas.py tests/test_models_compile.py`
- `pytest`
- `python -m app.main`

------
https://chatgpt.com/codex/tasks/task_e_68af6cb10ef0832594dc4691cacb51d7